### PR TITLE
BUG: Change container-guts dependency to Git repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "mcp>=1.0.0",
     "pyyaml>=6.0",
     "questionary>=2.0",
     "rich>=13.0",
@@ -50,7 +49,7 @@ Homepage = "https://github.com/shelley-bio/shelley-bio"
 Source = "https://github.com/shelley-bio/shelley-bio"
 
 [tool.uv.sources]
-container-guts = { path = "../guts", editable = true }
+container-guts = { git = "https://github.com/Sydney-Informatics-Hub/guts.git", branch = "singularity" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["shelley_bio"]


### PR DESCRIPTION
Updated the dependency for container-guts to use a Git repository instead of a local path to reflect new uv usage