### PR TITLE
ENH: Add shelley clean and versioned local registries

### DIFF
--- a/shelley/builder/cvmfs_builder.py
+++ b/shelley/builder/cvmfs_builder.py
@@ -338,9 +338,16 @@ class CVMFSModuleBuilder:
 
         return aliases
 
+    def _run_shpc_uninstall(self, uri_tag: str) -> Tuple[int, str]:
+        """Run `shpc uninstall --force <uri_tag>`. Returns (returncode, combined output)."""
+        result = subprocess.run(
+            _shpc_cmd("uninstall", "--force", uri_tag), capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout + result.stderr
+
     def _shpc_uninstall(self, uri_tag: str) -> None:
         """Uninstall an existing shpc entry (best-effort; ignores errors)."""
-        subprocess.run(_shpc_cmd("uninstall", "--force", uri_tag), capture_output=True, text=True)
+        self._run_shpc_uninstall(uri_tag)
 
     def _shpc_module_base(self) -> Path:
         """Ask shpc where it installed the module.
@@ -475,6 +482,77 @@ class CVMFSModuleBuilder:
             ))
 
         return dest
+
+    def uninstall_module(self, tool_name: str, version: str) -> dict:
+        """
+        Uninstall a specific tool@version: the inverse of shpc_install.
+
+        Runs `shpc uninstall --force` for the shpc-managed module/wrapper/container
+        artifacts, removes the Lmod modulefile symlink shelley creates directly (shpc
+        has no knowledge of it), and prunes the matching tag from a local registry
+        entry if shelley created one for this tool.
+
+        A local registry entry (local_registry()/<uri>/container.yaml) is only ever
+        written by _ensure_local_registry_entry, so if it exists at all it is entirely
+        shelley-owned: pruning just the tag for this version is safe regardless of
+        what else is in the file. The whole file is deleted only when that was the
+        last remaining tag.
+
+        Does not raise if `shpc uninstall` fails (e.g. shpc's own tracking already
+        lost the entry) — shelley's own state is independent and still gets cleaned
+        up. Returns a report describing exactly what was removed, for the caller to
+        render:
+
+            {
+                "uri_tag": str,
+                "shpc_removed": bool,
+                "shpc_output": str,
+                "modulefile_removed": bool,
+                "registry_tag_removed": bool,
+                "registry_entry_deleted": bool,
+            }
+        """
+        uri = f"quay.io/biocontainers/{tool_name}"
+        uri_tag = f"{uri}:{version}"
+
+        returncode, output = self._run_shpc_uninstall(uri_tag)
+        shpc_removed = returncode == 0
+        if not shpc_removed:
+            log.warning("shpc uninstall reported rc=%s for %s: %s", returncode, uri_tag, output.strip())
+
+        dest = self.lmod_modules_path / tool_name / f"{version}.lua"
+        modulefile_removed = False
+        if dest.is_symlink() or dest.exists():
+            dest.unlink()
+            modulefile_removed = True
+
+        registry_tag_removed = False
+        registry_entry_deleted = False
+        registry_yaml = gl.local_registry() / uri / "container.yaml"
+        if registry_yaml.is_file():
+            with open(registry_yaml) as f:
+                config = yaml.safe_load(f) or {}
+            tags = config.get("tags", {}) or {}
+            if version in tags:
+                del tags[version]
+                registry_tag_removed = True
+                if tags:
+                    config["tags"] = tags
+                    with open(registry_yaml, "w") as f:
+                        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                    share_file(registry_yaml)
+                else:
+                    registry_yaml.unlink()
+                    registry_entry_deleted = True
+
+        return {
+            "uri_tag": uri_tag,
+            "shpc_removed": shpc_removed,
+            "shpc_output": output,
+            "modulefile_removed": modulefile_removed,
+            "registry_tag_removed": registry_tag_removed,
+            "registry_entry_deleted": registry_entry_deleted,
+        }
 
     def list_versions(self, tool_name: str) -> List[str]:
         """

--- a/shelley/builder/cvmfs_builder.py
+++ b/shelley/builder/cvmfs_builder.py
@@ -282,23 +282,43 @@ class CVMFSModuleBuilder:
         """
         Create or update a local shpc registry entry, returning the aliases written.
 
-        Downloads the upstream container.yaml as a base (preserving other version tags
-        and tool metadata) and adds the SHA256 tag for this version.  Aliases come from
-        the upstream entry (when ``in_upstream``) or from a guts diff of the SIF
-        otherwise; when ``interactive`` is set they are curated interactively first.
+        Merges into the existing local container.yaml when one is already present —
+        only downloads a fresh upstream copy as the base when no local file exists
+        yet, so tags added by earlier local-only builds of this same tool survive
+        (a fresh copy can't restore them, since they don't exist upstream). Aliases
+        come from the upstream entry (when ``in_upstream``) or from a guts diff of
+        the SIF otherwise; when ``interactive`` is set they are curated
+        interactively first.
+
+        When the version is absent upstream, also creates a marker directory at
+        registry_dir/<version>/ containing an aliases.yaml snapshot of exactly this
+        version's own aliases. This is invisible to shpc — its filesystem registry
+        provider only ever looks for a file literally named container.yaml, never a
+        per-version subdirectory — but lets uninstall_module later prove that this
+        specific tag was a genuine local addition rather than cached upstream data,
+        before it prunes anything from the shared container.yaml. The snapshot
+        matters because config["aliases"] is one shared field across every tag in
+        this file: building a second not-upstream version overwrites it with that
+        version's own aliases, which can genuinely differ a lot from an older one's
+        (e.g. star-fusion:1.0.0 only aliases STAR; newer builds also alias salmon).
+        Without the snapshot, an earlier version's aliases would be unrecoverable
+        the moment a later one is built.
         """
         registry_dir = Path(local_registry or gl.local_registry()) / uri
         registry_yaml = registry_dir / "container.yaml"
         ensure_shared_dir(registry_dir)
 
-        # Download upstream entry as a base (best-effort; tool may not be in upstream at all)
-        remote_url = (
-            f"https://raw.githubusercontent.com/singularityhub/shpc-registry/main/{uri}/container.yaml"
-        )
-        subprocess.run(
-            ["curl", "-fsSL", remote_url, "-o", str(registry_yaml)],
-            capture_output=True, text=True,
-        )
+        if not registry_yaml.exists():
+            # Download upstream entry as a base (best-effort; tool may not be in
+            # upstream at all). Skipped when a local file already exists so this
+            # doesn't clobber tags added by earlier local-only builds of this tool.
+            remote_url = (
+                f"https://raw.githubusercontent.com/singularityhub/shpc-registry/main/{uri}/container.yaml"
+            )
+            subprocess.run(
+                ["curl", "-fsSL", remote_url, "-o", str(registry_yaml)],
+                capture_output=True, text=True,
+            )
 
         config = _load_registry_config(uri, registry_yaml)
         if not config:
@@ -335,6 +355,15 @@ class CVMFSModuleBuilder:
         # curl wrote this file above under the ambient umask; make it readable
         # unconditionally so every user's `shelley find` can consult the entry.
         share_file(registry_yaml)
+
+        if not in_upstream:
+            marker_dir = registry_dir / version
+            ensure_shared_dir(marker_dir)
+            aliases_snapshot = marker_dir / "aliases.yaml"
+            with open(aliases_snapshot, "w") as f:
+                yaml.dump({"version": version, "aliases": aliases}, f,
+                          default_flow_style=False, sort_keys=False)
+            share_file(aliases_snapshot)
 
         return aliases
 
@@ -492,16 +521,19 @@ class CVMFSModuleBuilder:
         (shpc has no knowledge of it) — pruning its parent tool directory too, if
         that was the last version installed for this tool.
 
-        Deliberately leaves local_registry()/<uri>/container.yaml untouched. That
-        file is not exclusively "owned" by one installed version the way the
-        modulefile symlink is: _load_registry_config also writes it as a cache of
-        the *entire* upstream shpc-registry the first time anything calls
-        get_registry_tags (e.g. `shelley find`, or version resolution during
-        `shelley build`), and even _ensure_local_registry_entry's own writes start
-        from a fresh curl of that same full upstream file. Deleting a tag from it on
-        uninstall would risk corrupting metadata that other installed versions and
-        unrelated commands still rely on, for no actual benefit — the file has no
-        bearing on whether a module is installed.
+        local_registry()/<uri>/container.yaml is not exclusively "owned" by one
+        installed version the way the modulefile symlink is: _load_registry_config
+        also writes it as a cache of the *entire* upstream shpc-registry the first
+        time anything calls get_registry_tags (e.g. `shelley find`, or version
+        resolution during `shelley build`). Its tags dict is only safe to prune when
+        _ensure_local_registry_entry left a registry_dir/<version>/ marker directory
+        (holding that version's own aliases.yaml snapshot) proving the tag was a
+        genuine local addition (absent upstream), not part of the shared cache — in
+        that case the one tag is removed and the whole marker directory (aliases
+        snapshot included) is deleted with it; the container.yaml file itself is
+        never deleted, since the remaining tags may still be cached upstream
+        metadata other commands rely on. Without a marker, container.yaml is left
+        completely untouched.
 
         Does not raise if `shpc uninstall` fails (e.g. shpc's own tracking already
         lost the entry) — shelley's own state is independent and still gets cleaned
@@ -513,6 +545,7 @@ class CVMFSModuleBuilder:
                 "shpc_removed": bool,
                 "shpc_output": str,
                 "modulefile_removed": bool,
+                "registry_tag_removed": bool,
             }
         """
         uri = f"quay.io/biocontainers/{tool_name}"
@@ -534,11 +567,30 @@ class CVMFSModuleBuilder:
             except OSError:
                 pass  # other versions of this tool are still installed
 
+        registry_tag_removed = False
+        registry_dir = gl.local_registry() / uri
+        marker_dir = registry_dir / version
+        if marker_dir.is_dir():
+            registry_yaml = registry_dir / "container.yaml"
+            if registry_yaml.is_file():
+                with open(registry_yaml) as f:
+                    config = yaml.safe_load(f) or {}
+                tags = config.get("tags", {}) or {}
+                if version in tags:
+                    del tags[version]
+                    config["tags"] = tags
+                    with open(registry_yaml, "w") as f:
+                        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                    share_file(registry_yaml)
+                    registry_tag_removed = True
+            shutil.rmtree(marker_dir, ignore_errors=True)
+
         return {
             "uri_tag": uri_tag,
             "shpc_removed": shpc_removed,
             "shpc_output": output,
             "modulefile_removed": modulefile_removed,
+            "registry_tag_removed": registry_tag_removed,
         }
 
     def list_versions(self, tool_name: str) -> List[str]:

--- a/shelley/builder/cvmfs_builder.py
+++ b/shelley/builder/cvmfs_builder.py
@@ -488,15 +488,20 @@ class CVMFSModuleBuilder:
         Uninstall a specific tool@version: the inverse of shpc_install.
 
         Runs `shpc uninstall --force` for the shpc-managed module/wrapper/container
-        artifacts, removes the Lmod modulefile symlink shelley creates directly (shpc
-        has no knowledge of it), and prunes the matching tag from a local registry
-        entry if shelley created one for this tool.
+        artifacts, and removes the Lmod modulefile symlink shelley creates directly
+        (shpc has no knowledge of it) — pruning its parent tool directory too, if
+        that was the last version installed for this tool.
 
-        A local registry entry (local_registry()/<uri>/container.yaml) is only ever
-        written by _ensure_local_registry_entry, so if it exists at all it is entirely
-        shelley-owned: pruning just the tag for this version is safe regardless of
-        what else is in the file. The whole file is deleted only when that was the
-        last remaining tag.
+        Deliberately leaves local_registry()/<uri>/container.yaml untouched. That
+        file is not exclusively "owned" by one installed version the way the
+        modulefile symlink is: _load_registry_config also writes it as a cache of
+        the *entire* upstream shpc-registry the first time anything calls
+        get_registry_tags (e.g. `shelley find`, or version resolution during
+        `shelley build`), and even _ensure_local_registry_entry's own writes start
+        from a fresh curl of that same full upstream file. Deleting a tag from it on
+        uninstall would risk corrupting metadata that other installed versions and
+        unrelated commands still rely on, for no actual benefit — the file has no
+        bearing on whether a module is installed.
 
         Does not raise if `shpc uninstall` fails (e.g. shpc's own tracking already
         lost the entry) — shelley's own state is independent and still gets cleaned
@@ -508,8 +513,6 @@ class CVMFSModuleBuilder:
                 "shpc_removed": bool,
                 "shpc_output": str,
                 "modulefile_removed": bool,
-                "registry_tag_removed": bool,
-                "registry_entry_deleted": bool,
             }
         """
         uri = f"quay.io/biocontainers/{tool_name}"
@@ -520,38 +523,22 @@ class CVMFSModuleBuilder:
         if not shpc_removed:
             log.warning("shpc uninstall reported rc=%s for %s: %s", returncode, uri_tag, output.strip())
 
-        dest = self.lmod_modules_path / tool_name / f"{version}.lua"
+        tool_dir = self.lmod_modules_path / tool_name
+        dest = tool_dir / f"{version}.lua"
         modulefile_removed = False
         if dest.is_symlink() or dest.exists():
             dest.unlink()
             modulefile_removed = True
-
-        registry_tag_removed = False
-        registry_entry_deleted = False
-        registry_yaml = gl.local_registry() / uri / "container.yaml"
-        if registry_yaml.is_file():
-            with open(registry_yaml) as f:
-                config = yaml.safe_load(f) or {}
-            tags = config.get("tags", {}) or {}
-            if version in tags:
-                del tags[version]
-                registry_tag_removed = True
-                if tags:
-                    config["tags"] = tags
-                    with open(registry_yaml, "w") as f:
-                        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-                    share_file(registry_yaml)
-                else:
-                    registry_yaml.unlink()
-                    registry_entry_deleted = True
+            try:
+                tool_dir.rmdir()
+            except OSError:
+                pass  # other versions of this tool are still installed
 
         return {
             "uri_tag": uri_tag,
             "shpc_removed": shpc_removed,
             "shpc_output": output,
             "modulefile_removed": modulefile_removed,
-            "registry_tag_removed": registry_tag_removed,
-            "registry_entry_deleted": registry_entry_deleted,
         }
 
     def list_versions(self, tool_name: str) -> List[str]:

--- a/shelley/client/cli.py
+++ b/shelley/client/cli.py
@@ -80,7 +80,7 @@ def main() -> None:
         force, positional = parse_force_flag(sys.argv[2:])
         if not positional:
             print_warning("Missing tool name or version")
-            print_info("Usage: [command]shelley clean <tool>:<version> [--force|-y][/command]")
+            print_info("Usage: [command]shelley clean <tool>:<version> [-y][/command]")
             print_info("Example: [command]shelley clean samtools:1.21[/command]")
             sys.exit(1)
         sys.exit(0 if clean_module(positional[0], force=force) else 1)

--- a/shelley/client/cli.py
+++ b/shelley/client/cli.py
@@ -9,10 +9,11 @@ import sys
 from pathlib import Path
 
 from ..commands.build import build_module
+from ..commands.clean import clean_module
 from ..commands.find import find_tool_sync
 from ..commands.interactive import interactive_mode
 from ..commands.search import search_tools
-from ..utils.args import parse_build_flags, parse_verbose
+from ..utils.args import parse_build_flags, parse_force_flag, parse_verbose
 from ..utils.commands import CORE_COMMANDS
 from ..utils.batch import batch_build_modules, read_tools_file
 from ..utils.style import (
@@ -74,6 +75,15 @@ def main() -> None:
                 sys.exit(1)
             sys.exit(batch_build_modules(tools))
         sys.exit(0 if build_module(arg, interactive=interactive) else 1)
+
+    if command == "clean":
+        force, positional = parse_force_flag(sys.argv[2:])
+        if not positional:
+            print_warning("Missing tool name or version")
+            print_info("Usage: [command]shelley clean <tool>:<version> [--force|-y][/command]")
+            print_info("Example: [command]shelley clean samtools:1.21[/command]")
+            sys.exit(1)
+        sys.exit(0 if clean_module(positional[0], force=force) else 1)
 
     if command == "find":
         verbose, positional = parse_verbose(sys.argv[2:])

--- a/shelley/commands/clean.py
+++ b/shelley/commands/clean.py
@@ -1,0 +1,151 @@
+"""Clean command — uninstall a specific tool@version. Inverse of `shelley build`."""
+
+import subprocess
+
+import questionary
+from rich.panel import Panel
+
+from ..builder.cvmfs_builder import CVMFSModuleBuilder
+from ..commands.build import needs_sudo, reexec_command, sudo_env_args
+from ..commands.find import list_installed_versions
+from ..utils.modules import load_build_modules
+from ..utils.perms import apply_build_umask
+from ..utils.style import console, ShelleyStyle, print_info, print_warning, print_error
+
+
+def _parse_tool_spec(tool_spec: str) -> tuple[str, str | None]:
+    """Split '<tool>:<version>' or '<tool>/<version>' (both separators, like build)."""
+    if "/" in tool_spec:
+        tool_name, version = tool_spec.split("/", 1)
+    elif ":" in tool_spec:
+        tool_name, version = tool_spec.split(":", 1)
+    else:
+        tool_name, version = tool_spec, None
+    return tool_name, version
+
+
+def _resolve_installed_version(tool_name: str, version_spec: str) -> str:
+    """Match version_spec (full or short) against installed modulefiles for tool_name.
+
+    Mirrors the short/full version matching used at build time (e.g. "1.21" matching
+    "1.21--h96c455f_1"), but against what is actually installed rather than what CVMFS
+    has available — clean has no reason to require CVMFS to be mounted.
+
+    Raises ValueError when there is no match, or more than one (an ambiguous short
+    version with two installed hash-suffixed builds).
+    """
+    installed = list_installed_versions(tool_name)
+    matches = [v for v in installed if v == version_spec or v.split("--", 1)[0] == version_spec]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise ValueError(f"Version '{version_spec}' is not installed for '{tool_name}'.")
+    raise ValueError(
+        f"'{version_spec}' matches more than one installed build of '{tool_name}': "
+        f"{', '.join(matches)}. Specify the full version string."
+    )
+
+
+def _not_installed_panel(
+    tool_name: str, requested_version: str | None, detail: str | None = None,
+) -> Panel:
+    """Error panel for 'no version given' and 'version not installed', listing what is."""
+    installed = list_installed_versions(tool_name)
+    if installed:
+        versions_text = "\n".join(f"  • {v}" for v in installed)
+        suggestion = (
+            f"Currently installed versions of '{tool_name}':\n{versions_text}\n\n"
+            f"Re-run with one of these, e.g.:\n"
+            f"shelley clean {tool_name}:{installed[0]}"
+        )
+    else:
+        suggestion = f"'{tool_name}' has no installed versions to clean."
+
+    if requested_version is None:
+        message = f"shelley clean requires an explicit version, e.g. {tool_name}:<version>."
+    else:
+        message = detail or f"Version '{requested_version}' is not installed for '{tool_name}'."
+
+    return ShelleyStyle.create_error_panel("Not Installed", message, suggestion)
+
+
+def clean_module(tool_spec: str, force: bool = False) -> bool:
+    """Uninstall a specific tool@version. Requires an explicit version.
+
+    Confirms interactively before deleting anything, unless force=True (the
+    --force/-y flag). Version resolution and the confirmation prompt both happen
+    before any sudo re-exec, so a bad/ambiguous/missing version is reported without
+    ever asking for a password, and the confirmation runs in the process attached to
+    the user's terminal rather than racing sudo's own prompt on the same TTY. The
+    re-exec'd child is always invoked with --force, since confirmation already
+    happened in the parent.
+
+    Returns True if tool@version was cleaned, False on error or user decline.
+    """
+    tool_name, requested_version = _parse_tool_spec(tool_spec)
+
+    if requested_version is None:
+        console.print(_not_installed_panel(tool_name, None))
+        return False
+
+    try:
+        version = _resolve_installed_version(tool_name, requested_version)
+    except ValueError as e:
+        console.print(_not_installed_panel(tool_name, requested_version, str(e)))
+        return False
+
+    if not force:
+        confirmed = questionary.confirm(
+            f"Remove {tool_name}/{version}? This deletes its module, wrappers, "
+            "and container artifacts.",
+            default=False,
+        ).ask()
+        if not confirmed:
+            print_warning("Clean cancelled; nothing was removed.")
+            return False
+
+    if needs_sudo():
+        launcher = reexec_command()
+        if launcher is None:
+            print_error("Could not locate the 'shelley' executable on PATH")
+            return False
+
+        cmd = [
+            "sudo", "-E", "env", *sudo_env_args(),
+            *launcher, "clean", f"{tool_name}:{version}", "--force",
+        ]
+        try:
+            print_info(f"Running with elevated privileges: clean {tool_name}:{version}")
+            result = subprocess.run(cmd, check=False)
+            if result.returncode != 0:
+                print_error(f"Clean failed with exit code {result.returncode}")
+                return False
+            return True
+        except KeyboardInterrupt:
+            print_warning("Clean cancelled by user")
+            return False
+
+    apply_build_umask()
+    load_build_modules()
+
+    builder = CVMFSModuleBuilder()
+    try:
+        with ShelleyStyle.create_status(f"Removing {tool_name}/{version}"):
+            report = builder.uninstall_module(tool_name, version)
+    except OSError as e:
+        console.print(ShelleyStyle.create_error_panel(
+            "Clean Failed", str(e),
+            "Check write access to the shared build directories",
+        ))
+        return False
+
+    if not report["shpc_removed"]:
+        console.print(ShelleyStyle.create_warning_panel(
+            "shpc uninstall reported an issue",
+            f"{report['uri_tag']}: {(report['shpc_output'] or '').strip() or 'non-zero exit'} "
+            "— shelley-managed state (modulefile symlink, local registry entry) was "
+            "still cleaned up.",
+        ))
+
+    console.print(ShelleyStyle.create_clean_success(tool_name, version, report))
+    return True

--- a/shelley/commands/clean.py
+++ b/shelley/commands/clean.py
@@ -72,12 +72,12 @@ def _not_installed_panel(
 def clean_module(tool_spec: str, force: bool = False) -> bool:
     """Uninstall a specific tool@version. Requires an explicit version.
 
-    Confirms interactively before deleting anything, unless force=True (the
-    --force/-y flag). Version resolution and the confirmation prompt both happen
-    before any sudo re-exec, so a bad/ambiguous/missing version is reported without
-    ever asking for a password, and the confirmation runs in the process attached to
+    Confirms interactively before deleting anything, unless force=True (the -y
+    flag). Version resolution and the confirmation prompt both happen before any
+    sudo re-exec, so a bad/ambiguous/missing version is reported without ever
+    asking for a password, and the confirmation runs in the process attached to
     the user's terminal rather than racing sudo's own prompt on the same TTY. The
-    re-exec'd child is always invoked with --force, since confirmation already
+    re-exec'd child is always invoked with -y, since confirmation already
     happened in the parent.
 
     Returns True if tool@version was cleaned, False on error or user decline.
@@ -112,7 +112,7 @@ def clean_module(tool_spec: str, force: bool = False) -> bool:
 
         cmd = [
             "sudo", "-E", "env", *sudo_env_args(),
-            *launcher, "clean", f"{tool_name}:{version}", "--force",
+            *launcher, "clean", f"{tool_name}:{version}", "-y",
         ]
         try:
             print_info(f"Running with elevated privileges: clean {tool_name}:{version}")
@@ -143,8 +143,7 @@ def clean_module(tool_spec: str, force: bool = False) -> bool:
         console.print(ShelleyStyle.create_warning_panel(
             "shpc uninstall reported an issue",
             f"{report['uri_tag']}: {(report['shpc_output'] or '').strip() or 'non-zero exit'} "
-            "— shelley-managed state (modulefile symlink, local registry entry) was "
-            "still cleaned up.",
+            "— the Lmod modulefile symlink was still cleaned up.",
         ))
 
     console.print(ShelleyStyle.create_clean_success(tool_name, version, report))

--- a/shelley/commands/find.py
+++ b/shelley/commands/find.py
@@ -30,6 +30,19 @@ def module_is_installed(tool_id: str, version: str) -> bool:
     return any(p.is_file() for p in (lmod_modules() / tool_id).glob(f"{version}*.lua"))
 
 
+def list_installed_versions(tool_id: str) -> list[str]:
+    """Every version with a modulefile under lmod_modules()/tool_id, dangling or not.
+
+    Unlike module_is_installed, this does not require the symlink to resolve — a
+    dangling modulefile is exactly the kind of leftover `shelley clean` should be able
+    to target, and should still be listed when helping a user pick a version to clean.
+    """
+    tool_dir = lmod_modules() / tool_id
+    if not tool_dir.is_dir():
+        return []
+    return sorted(p.stem for p in tool_dir.glob("*.lua"))
+
+
 def find_tool_sync(tool_name: str, verbose: bool = False) -> None:
     """Find a tool by name using RSEC + CVMFS cache (no MCP server needed).
 

--- a/shelley/commands/interactive.py
+++ b/shelley/commands/interactive.py
@@ -65,6 +65,6 @@ def interactive_mode() -> None:
             if positional:
                 clean_module(positional[0], force=force)
             else:
-                print_warning("Usage: clean <tool>:<version> [--force|-y]")
+                print_warning("Usage: clean <tool>:<version> [-y]")
         else:
             print_warning(f"Unknown command: '{cmd}'. Type help for usage.")

--- a/shelley/commands/interactive.py
+++ b/shelley/commands/interactive.py
@@ -1,9 +1,10 @@
 """Interactive command — guided REPL for shelley."""
 
 from .build import build_module
+from .clean import clean_module
 from .find import find_tool_sync
 from .search import search_tools
-from ..utils.args import parse_build_flags, parse_verbose
+from ..utils.args import parse_build_flags, parse_force_flag, parse_verbose
 from ..utils.commands import CORE_COMMANDS
 from ..utils.style import (
     console, ShelleyStyle, print_banner, print_rule,
@@ -59,5 +60,11 @@ def interactive_mode() -> None:
                 build_module(positional[0], interactive=interactive)
             else:
                 print_warning("Usage: build <tool_name>[/version] [-i|--interactive]")
+        elif cmd == "clean":
+            force, positional = parse_force_flag(parts[1:])
+            if positional:
+                clean_module(positional[0], force=force)
+            else:
+                print_warning("Usage: clean <tool>:<version> [--force|-y]")
         else:
             print_warning(f"Unknown command: '{cmd}'. Type help for usage.")

--- a/shelley/utils/args.py
+++ b/shelley/utils/args.py
@@ -39,13 +39,13 @@ def parse_build_flags(args: list[str]) -> tuple[bool, list[str]]:
 def parse_force_flag(args: list[str]) -> tuple[bool, list[str]]:
     """Split ``clean`` flags from positional args.
 
-    Recognises ``--force``/``-y``, which skips the interactive removal confirmation.
+    Recognises ``-y``, which skips the interactive removal confirmation.
     Returns ``(force, positionals)``.
     """
     force = False
     positional: list[str] = []
     for arg in args:
-        if arg in ("--force", "-y"):
+        if arg == "-y":
             force = True
         else:
             positional.append(arg)

--- a/shelley/utils/args.py
+++ b/shelley/utils/args.py
@@ -34,3 +34,19 @@ def parse_build_flags(args: list[str]) -> tuple[bool, list[str]]:
         else:
             positional.append(arg)
     return interactive, positional
+
+
+def parse_force_flag(args: list[str]) -> tuple[bool, list[str]]:
+    """Split ``clean`` flags from positional args.
+
+    Recognises ``--force``/``-y``, which skips the interactive removal confirmation.
+    Returns ``(force, positionals)``.
+    """
+    force = False
+    positional: list[str] = []
+    for arg in args:
+        if arg in ("--force", "-y"):
+            force = True
+        else:
+            positional.append(arg)
+    return force, positional

--- a/shelley/utils/commands.py
+++ b/shelley/utils/commands.py
@@ -16,4 +16,7 @@ CORE_COMMANDS = [
     {"command": r"build <tool\[/version]> [-i]",
      "description": "Build Lmod module for tool; -i/--interactive to curate aliases",
      "example": "build samtools/1.21"},
+    {"command": r"clean <tool>:<version> [--force|-y]",
+     "description": "Uninstall a specific tool version; requires an explicit version",
+     "example": "clean samtools:1.21"},
 ]

--- a/shelley/utils/commands.py
+++ b/shelley/utils/commands.py
@@ -16,7 +16,7 @@ CORE_COMMANDS = [
     {"command": r"build <tool\[/version]> [-i]",
      "description": "Build Lmod module for tool; -i/--interactive to curate aliases",
      "example": "build samtools/1.21"},
-    {"command": r"clean <tool>:<version> [--force|-y]",
-     "description": "Uninstall a specific tool version; requires an explicit version",
+    {"command": r"clean <tool>:<version> [-y]",
+     "description": "Uninstall a specific tool version; -y skips the confirmation prompt",
      "example": "clean samtools:1.21"},
 ]

--- a/shelley/utils/style.py
+++ b/shelley/utils/style.py
@@ -278,10 +278,6 @@ class ShelleyStyle:
             removed.append("shpc module, wrappers and container artifacts")
         if report.get("modulefile_removed"):
             removed.append("Lmod modulefile symlink")
-        if report.get("registry_entry_deleted"):
-            removed.append("local registry entry (last remaining version)")
-        elif report.get("registry_tag_removed"):
-            removed.append("local registry tag")
         removed_text = "\n".join(f"  [muted]• {item}[/muted]" for item in removed) or \
             "  [muted]• nothing further to remove[/muted]"
 
@@ -384,6 +380,8 @@ class ShelleyStyle:
             ("Search for RNA-seq tools", "shelley search 'RNA sequencing'"),
             ("Build latest version", "shelley build samtools"),
             ("Build specific version", "shelley build samtools/1.21"),
+            ("Uninstall a tool version", "shelley clean samtools:1.21"),
+            ("Uninstall without confirming", "shelley clean samtools:1.21 -y"),
             ("Interactive mode", "shelley interactive")
         ]
         

--- a/shelley/utils/style.py
+++ b/shelley/utils/style.py
@@ -278,6 +278,8 @@ class ShelleyStyle:
             removed.append("shpc module, wrappers and container artifacts")
         if report.get("modulefile_removed"):
             removed.append("Lmod modulefile symlink")
+        if report.get("registry_tag_removed"):
+            removed.append("local registry tag (was added locally, not upstream)")
         removed_text = "\n".join(f"  [muted]• {item}[/muted]" for item in removed) or \
             "  [muted]• nothing further to remove[/muted]"
 

--- a/shelley/utils/style.py
+++ b/shelley/utils/style.py
@@ -266,10 +266,41 @@ class ShelleyStyle:
             content,
             title="[status.success]Build Complete[/status.success]",
             box=ROUNDED,
-            border_style="success", 
+            border_style="success",
             padding=(1, 2)
         )
-    
+
+    @staticmethod
+    def create_clean_success(tool_name: str, version: str, report: Dict[str, Any]) -> Panel:
+        """Create a styled clean/uninstall success message."""
+        removed = []
+        if report.get("shpc_removed"):
+            removed.append("shpc module, wrappers and container artifacts")
+        if report.get("modulefile_removed"):
+            removed.append("Lmod modulefile symlink")
+        if report.get("registry_entry_deleted"):
+            removed.append("local registry entry (last remaining version)")
+        elif report.get("registry_tag_removed"):
+            removed.append("local registry tag")
+        removed_text = "\n".join(f"  [muted]• {item}[/muted]" for item in removed) or \
+            "  [muted]• nothing further to remove[/muted]"
+
+        content = f"""[status.success]✅ Module Removed[/status.success]
+
+[header]Tool:[/header] [tool]{tool_name}[/tool]
+[header]Version:[/header] [version]{version}[/version]
+
+[header]Removed:[/header]
+{removed_text}"""
+
+        return Panel(
+            content,
+            title="[status.success]Clean Complete[/status.success]",
+            box=ROUNDED,
+            border_style="success",
+            padding=(1, 2)
+        )
+
     @staticmethod
     def create_build_info(tool_name: str, version: str, available_versions: List[str]) -> Panel:
         """Create build information panel for version selection."""

--- a/tests/test_clean_command.py
+++ b/tests/test_clean_command.py
@@ -104,49 +104,57 @@ def test_uninstall_dangling_symlink_only(builder):
     assert not link.is_symlink()
 
 
-def test_uninstall_removes_only_matching_tag_when_multiple_tags_present(builder):
+def test_uninstall_prunes_the_now_empty_tool_directory(builder):
+    """The parent tool dir under lmod_modules must not linger once its last version goes."""
+    link_dir = builder.lmod_modules_path / TOOL
+    link_dir.mkdir(parents=True)
+    (link_dir / f"{VERSION}.lua").symlink_to(link_dir / "does-not-exist.lua")
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        builder.uninstall_module(TOOL, VERSION)
+
+    assert not link_dir.exists()
+
+
+def test_uninstall_keeps_the_tool_directory_when_other_versions_remain(builder):
     other_version = "1.20--abc"
-    registry_yaml = _registry_yaml({VERSION: "sha256:aaa", other_version: "sha256:bbb"})
+    link_dir = builder.lmod_modules_path / TOOL
+    link_dir.mkdir(parents=True)
+    (link_dir / f"{VERSION}.lua").symlink_to(link_dir / "does-not-exist.lua")
+    (link_dir / f"{other_version}.lua").symlink_to(link_dir / "also-missing.lua")
 
     with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
-        report = builder.uninstall_module(TOOL, VERSION)
+        builder.uninstall_module(TOOL, VERSION)
 
-    assert report["registry_tag_removed"] is True
-    assert report["registry_entry_deleted"] is False
-    assert registry_yaml.is_file()
-    config = yaml.safe_load(registry_yaml.read_text())
-    assert config["tags"] == {other_version: "sha256:bbb"}
-    assert config["aliases"]
+    assert link_dir.is_dir()
+    assert (link_dir / f"{other_version}.lua").is_symlink()
 
 
-def test_uninstall_deletes_whole_registry_entry_when_last_tag_removed(builder):
-    registry_yaml = _registry_yaml({VERSION: "sha256:aaa"})
+def test_uninstall_never_touches_the_local_registry_cache(builder):
+    """container.yaml is a shared upstream cache/mirror, not per-version state — clean
+    must leave it byte-for-byte alone, even when it happens to list this version."""
+    registry_yaml = _registry_yaml({VERSION: "sha256:aaa", "1.20--abc": "sha256:bbb"})
+    before = registry_yaml.read_text()
 
     with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
-        report = builder.uninstall_module(TOOL, VERSION)
+        builder.uninstall_module(TOOL, VERSION)
 
-    assert report["registry_entry_deleted"] is True
-    assert not registry_yaml.exists()
-
-
-def test_uninstall_is_a_noop_for_registry_when_no_local_entry_exists(builder):
-    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
-        report = builder.uninstall_module(TOOL, VERSION)
-
-    assert report["registry_tag_removed"] is False
-    assert report["registry_entry_deleted"] is False
+    assert registry_yaml.read_text() == before
 
 
-def test_uninstall_leaves_shelley_state_clean_even_when_shpc_uninstall_fails(builder):
-    """The two cleanup paths are independent: a failed shpc call must not block the rest."""
-    registry_yaml = _registry_yaml({VERSION: "sha256:aaa"})
+def test_uninstall_removes_shelley_state_even_when_shpc_uninstall_fails(builder):
+    """shpc failing to find its own entry must not block the rest of the cleanup."""
+    link_dir = builder.lmod_modules_path / TOOL
+    link_dir.mkdir(parents=True)
+    link = link_dir / f"{VERSION}.lua"
+    link.symlink_to(link_dir / "does-not-exist.lua")
 
     with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(1, "boom")):
         report = builder.uninstall_module(TOOL, VERSION)
 
     assert report["shpc_removed"] is False
-    assert report["registry_tag_removed"] is True
-    assert not registry_yaml.exists()
+    assert report["modulefile_removed"] is True
+    assert not link_dir.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -202,8 +210,7 @@ def mock_clean_builder():
     fake_builder = MagicMock(spec=CVMFSModuleBuilder)
     fake_builder.uninstall_module.return_value = {
         "uri_tag": URI_TAG, "shpc_removed": True, "shpc_output": "",
-        "modulefile_removed": True, "registry_tag_removed": False,
-        "registry_entry_deleted": False,
+        "modulefile_removed": True,
     }
 
     with patch("shelley.commands.clean.CVMFSModuleBuilder", return_value=fake_builder), \
@@ -230,8 +237,7 @@ def test_clean_module_warns_when_shpc_uninstall_reports_failure(mock_clean_build
     _touch_modulefile(TOOL, VERSION)
     mock_clean_builder.uninstall_module.return_value = {
         "uri_tag": URI_TAG, "shpc_removed": False, "shpc_output": "boom",
-        "modulefile_removed": True, "registry_tag_removed": False,
-        "registry_entry_deleted": False,
+        "modulefile_removed": True,
     }
 
     with patch("shelley.commands.clean.ShelleyStyle.create_warning_panel") as mock_warning:
@@ -293,7 +299,7 @@ def test_clean_module_prompts_when_not_forced_and_user_confirms(mock_clean_build
 
 def test_clean_module_reexecs_under_sudo_with_force_and_resolved_full_version():
     """The short version is resolved and confirmation happens before the re-exec;
-    the elevated child is always invoked with --force."""
+    the elevated child is always invoked with -y."""
     _touch_modulefile(TOOL, VERSION)
 
     with patch("shelley.commands.clean.needs_sudo", return_value=True), \
@@ -305,7 +311,7 @@ def test_clean_module_reexecs_under_sudo_with_force_and_resolved_full_version():
 
     assert result is True
     cmd = mock_run.call_args[0][0]
-    assert cmd[-3:] == ["clean", f"{TOOL}:{VERSION}", "--force"]
+    assert cmd[-3:] == ["clean", f"{TOOL}:{VERSION}", "-y"]
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +336,7 @@ def test_cli_clean_missing_args_exits_with_usage(monkeypatch):
 def test_cli_clean_dispatches_to_clean_module(monkeypatch):
     from shelley.client.cli import main
 
-    monkeypatch.setattr(sys, "argv", ["shelley", "clean", f"{TOOL}:{VERSION}", "--force"])
+    monkeypatch.setattr(sys, "argv", ["shelley", "clean", f"{TOOL}:{VERSION}", "-y"])
 
     with patch("shelley.client.cli.clean_module", return_value=True) as mock_clean:
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_clean_command.py
+++ b/tests/test_clean_command.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Tests for `shelley clean` — the inverse of `shelley build`."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from shelley.builder.cvmfs_builder import CVMFSModuleBuilder
+from shelley.commands.clean import (
+    _not_installed_panel, _resolve_installed_version, clean_module,
+)
+from shelley.commands.find import list_installed_versions
+from shelley.utils import globals as gl
+from shelley.utils.style import console
+
+TOOL, VERSION = "samtools", "1.21--h96c455f_1"
+URI = f"quay.io/biocontainers/{TOOL}"
+URI_TAG = f"{URI}:{VERSION}"
+
+
+def _fake_run(returncode: int = 0, output: str = "", calls: list | None = None):
+    """subprocess.run side effect covering `shpc uninstall`."""
+    def run(cmd, **_):
+        if calls is not None:
+            calls.append(list(cmd))
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = output
+        m.stderr = ""
+        return m
+    return run
+
+
+def _registry_yaml(tags: dict, aliases=None) -> Path:
+    registry_dir = gl.local_registry() / URI
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    yaml_path = registry_dir / "container.yaml"
+    config = {
+        "docker": URI,
+        "tags": tags,
+        "aliases": aliases or [{"name": TOOL, "command": f"/usr/local/bin/{TOOL}"}],
+    }
+    with open(yaml_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+    return yaml_path
+
+
+def _touch_modulefile(tool: str, version: str) -> Path:
+    """Create an installed modulefile marker under the (conftest-redirected) shared root."""
+    d = gl.lmod_modules() / tool
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{version}.lua"
+    path.write_text("-- module\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CVMFSModuleBuilder.uninstall_module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def builder(tmp_path) -> CVMFSModuleBuilder:
+    return CVMFSModuleBuilder(lmod_modules=str(tmp_path / "modulefiles"))
+
+
+def test_uninstall_removes_modulefile_symlink_and_calls_shpc_uninstall(builder, tmp_path):
+    link_dir = builder.lmod_modules_path / TOOL
+    link_dir.mkdir(parents=True)
+    target = tmp_path / "module.lua"
+    target.write_text("-- module\n")
+    link = link_dir / f"{VERSION}.lua"
+    link.symlink_to(target)
+
+    calls: list[list[str]] = []
+    with patch("shelley.builder.cvmfs_builder.subprocess.run",
+               side_effect=_fake_run(0, "Module was uninstalled.\n", calls)):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["shpc_removed"] is True
+    assert report["modulefile_removed"] is True
+    assert not link.exists() and not link.is_symlink()
+    assert any("uninstall" in c and "--force" in c and URI_TAG in c for c in calls)
+
+
+def test_uninstall_dangling_symlink_only(builder):
+    """shpc has nothing to remove, but shelley's own symlink must still go."""
+    link_dir = builder.lmod_modules_path / TOOL
+    link_dir.mkdir(parents=True)
+    link = link_dir / f"{VERSION}.lua"
+    link.symlink_to(link_dir / "does-not-exist.lua")
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run",
+               side_effect=_fake_run(1, "not found in module_base\n")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["shpc_removed"] is False
+    assert report["modulefile_removed"] is True
+    assert not link.is_symlink()
+
+
+def test_uninstall_removes_only_matching_tag_when_multiple_tags_present(builder):
+    other_version = "1.20--abc"
+    registry_yaml = _registry_yaml({VERSION: "sha256:aaa", other_version: "sha256:bbb"})
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["registry_tag_removed"] is True
+    assert report["registry_entry_deleted"] is False
+    assert registry_yaml.is_file()
+    config = yaml.safe_load(registry_yaml.read_text())
+    assert config["tags"] == {other_version: "sha256:bbb"}
+    assert config["aliases"]
+
+
+def test_uninstall_deletes_whole_registry_entry_when_last_tag_removed(builder):
+    registry_yaml = _registry_yaml({VERSION: "sha256:aaa"})
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["registry_entry_deleted"] is True
+    assert not registry_yaml.exists()
+
+
+def test_uninstall_is_a_noop_for_registry_when_no_local_entry_exists(builder):
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["registry_tag_removed"] is False
+    assert report["registry_entry_deleted"] is False
+
+
+def test_uninstall_leaves_shelley_state_clean_even_when_shpc_uninstall_fails(builder):
+    """The two cleanup paths are independent: a failed shpc call must not block the rest."""
+    registry_yaml = _registry_yaml({VERSION: "sha256:aaa"})
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(1, "boom")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["shpc_removed"] is False
+    assert report["registry_tag_removed"] is True
+    assert not registry_yaml.exists()
+
+
+# ---------------------------------------------------------------------------
+# Version resolution against what's actually installed
+# ---------------------------------------------------------------------------
+
+def test_resolve_installed_version_matches_short_and_full():
+    _touch_modulefile(TOOL, "1.22--hdfd78af_0")
+
+    assert _resolve_installed_version(TOOL, "1.22") == "1.22--hdfd78af_0"
+    assert _resolve_installed_version(TOOL, "1.22--hdfd78af_0") == "1.22--hdfd78af_0"
+
+
+def test_resolve_installed_version_raises_when_not_installed():
+    with pytest.raises(ValueError):
+        _resolve_installed_version(TOOL, "9.9")
+
+
+def test_resolve_installed_version_raises_when_ambiguous():
+    _touch_modulefile(TOOL, "1.21--aaa")
+    _touch_modulefile(TOOL, "1.21--bbb")
+
+    with pytest.raises(ValueError) as exc:
+        _resolve_installed_version(TOOL, "1.21")
+    assert "1.21--aaa" in str(exc.value)
+    assert "1.21--bbb" in str(exc.value)
+
+
+def test_list_installed_versions_includes_dangling_symlinks():
+    d = gl.lmod_modules() / TOOL
+    d.mkdir(parents=True)
+    (d / f"{VERSION}.lua").symlink_to(d / "nowhere.lua")
+
+    assert list_installed_versions(TOOL) == [VERSION]
+
+
+def test_not_installed_panel_lists_installed_versions():
+    _touch_modulefile(TOOL, VERSION)
+
+    with console.capture() as cap:
+        console.print(_not_installed_panel(TOOL, None))
+
+    assert VERSION in cap.get()
+
+
+# ---------------------------------------------------------------------------
+# clean_module end to end
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_clean_builder():
+    """Patch CVMFSModuleBuilder inside clean.py with a mock instance (no sudo needed)."""
+    fake_builder = MagicMock(spec=CVMFSModuleBuilder)
+    fake_builder.uninstall_module.return_value = {
+        "uri_tag": URI_TAG, "shpc_removed": True, "shpc_output": "",
+        "modulefile_removed": True, "registry_tag_removed": False,
+        "registry_entry_deleted": False,
+    }
+
+    with patch("shelley.commands.clean.CVMFSModuleBuilder", return_value=fake_builder), \
+         patch("shelley.commands.clean.ShelleyStyle.create_status") as mock_status, \
+         patch("shelley.commands.clean.console"), \
+         patch("shelley.commands.clean.load_build_modules"), \
+         patch("shelley.commands.clean.apply_build_umask"), \
+         patch("shelley.commands.clean.needs_sudo", return_value=False):
+        mock_status.return_value.__enter__ = MagicMock(return_value=None)
+        mock_status.return_value.__exit__ = MagicMock(return_value=False)
+        yield fake_builder
+
+
+def test_clean_module_happy_path_removes_everything(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+
+    result = clean_module(f"{TOOL}:{VERSION}", force=True)
+
+    assert result is True
+    mock_clean_builder.uninstall_module.assert_called_once_with(TOOL, VERSION)
+
+
+def test_clean_module_warns_when_shpc_uninstall_reports_failure(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+    mock_clean_builder.uninstall_module.return_value = {
+        "uri_tag": URI_TAG, "shpc_removed": False, "shpc_output": "boom",
+        "modulefile_removed": True, "registry_tag_removed": False,
+        "registry_entry_deleted": False,
+    }
+
+    with patch("shelley.commands.clean.ShelleyStyle.create_warning_panel") as mock_warning:
+        result = clean_module(f"{TOOL}:{VERSION}", force=True)
+
+    assert result is True
+    mock_warning.assert_called_once()
+
+
+def test_clean_module_errors_with_no_version(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+
+    result = clean_module(TOOL)
+
+    assert result is False
+    mock_clean_builder.uninstall_module.assert_not_called()
+
+
+def test_clean_module_errors_when_version_not_installed(mock_clean_builder):
+    _touch_modulefile(TOOL, "9.9--zzz")
+
+    result = clean_module(f"{TOOL}:1.0")
+
+    assert result is False
+    mock_clean_builder.uninstall_module.assert_not_called()
+
+
+def test_clean_module_force_skips_confirmation_prompt(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+
+    with patch("shelley.commands.clean.questionary.confirm") as mock_confirm:
+        result = clean_module(f"{TOOL}:{VERSION}", force=True)
+
+    assert result is True
+    mock_confirm.assert_not_called()
+
+
+def test_clean_module_prompts_when_not_forced_and_user_declines(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+
+    with patch("shelley.commands.clean.questionary.confirm") as mock_confirm:
+        mock_confirm.return_value.ask.return_value = False
+        result = clean_module(f"{TOOL}:{VERSION}")
+
+    assert result is False
+    mock_clean_builder.uninstall_module.assert_not_called()
+
+
+def test_clean_module_prompts_when_not_forced_and_user_confirms(mock_clean_builder):
+    _touch_modulefile(TOOL, VERSION)
+
+    with patch("shelley.commands.clean.questionary.confirm") as mock_confirm:
+        mock_confirm.return_value.ask.return_value = True
+        result = clean_module(f"{TOOL}:{VERSION}")
+
+    assert result is True
+    mock_clean_builder.uninstall_module.assert_called_once_with(TOOL, VERSION)
+
+
+def test_clean_module_reexecs_under_sudo_with_force_and_resolved_full_version():
+    """The short version is resolved and confirmation happens before the re-exec;
+    the elevated child is always invoked with --force."""
+    _touch_modulefile(TOOL, VERSION)
+
+    with patch("shelley.commands.clean.needs_sudo", return_value=True), \
+         patch("shelley.commands.clean.reexec_command",
+               return_value=[sys.executable, "-m", "shelley"]), \
+         patch("shelley.commands.clean.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = clean_module(f"{TOOL}:1.21", force=True)
+
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert cmd[-3:] == ["clean", f"{TOOL}:{VERSION}", "--force"]
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch: `shelley clean` with no args must not fall through to
+# "Unknown Command" the way bare `shelley build` currently does.
+# ---------------------------------------------------------------------------
+
+def test_cli_clean_missing_args_exits_with_usage(monkeypatch):
+    from shelley.client.cli import main
+
+    monkeypatch.setattr(sys, "argv", ["shelley", "clean"])
+
+    with patch("shelley.client.cli.clean_module") as mock_clean, \
+         patch("shelley.client.cli.console"):
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 1
+    mock_clean.assert_not_called()
+
+
+def test_cli_clean_dispatches_to_clean_module(monkeypatch):
+    from shelley.client.cli import main
+
+    monkeypatch.setattr(sys, "argv", ["shelley", "clean", f"{TOOL}:{VERSION}", "--force"])
+
+    with patch("shelley.client.cli.clean_module", return_value=True) as mock_clean:
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    mock_clean.assert_called_once_with(f"{TOOL}:{VERSION}", force=True)

--- a/tests/test_clean_command.py
+++ b/tests/test_clean_command.py
@@ -131,8 +131,9 @@ def test_uninstall_keeps_the_tool_directory_when_other_versions_remain(builder):
 
 
 def test_uninstall_never_touches_the_local_registry_cache(builder):
-    """container.yaml is a shared upstream cache/mirror, not per-version state — clean
-    must leave it byte-for-byte alone, even when it happens to list this version."""
+    """Without a marker directory, container.yaml is a shared upstream cache/mirror,
+    not per-version state — clean must leave it byte-for-byte alone, even when it
+    happens to list this version."""
     registry_yaml = _registry_yaml({VERSION: "sha256:aaa", "1.20--abc": "sha256:bbb"})
     before = registry_yaml.read_text()
 
@@ -140,6 +141,39 @@ def test_uninstall_never_touches_the_local_registry_cache(builder):
         builder.uninstall_module(TOOL, VERSION)
 
     assert registry_yaml.read_text() == before
+
+
+def test_uninstall_prunes_the_tag_when_a_marker_directory_proves_it_was_local(builder):
+    """A registry_dir/<version>/ marker (left by _ensure_local_registry_entry when the
+    tag was absent upstream) proves this one tag is safe to remove — everything else
+    in container.yaml must be left alone, and the file itself is never deleted."""
+    other_version = "1.20--abc"
+    registry_yaml = _registry_yaml({VERSION: "sha256:aaa", other_version: "sha256:bbb"})
+    marker_dir = gl.local_registry() / URI / VERSION
+    marker_dir.mkdir(parents=True)
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["registry_tag_removed"] is True
+    assert not marker_dir.exists()
+    assert registry_yaml.is_file()
+    config = yaml.safe_load(registry_yaml.read_text())
+    assert config["tags"] == {other_version: "sha256:bbb"}
+    assert config["aliases"]
+
+
+def test_uninstall_marker_present_but_no_container_yaml_is_a_noop(builder):
+    """A leftover marker with no container.yaml (already removed by hand, say) must
+    not raise."""
+    marker_dir = gl.local_registry() / URI / VERSION
+    marker_dir.mkdir(parents=True)
+
+    with patch("shelley.builder.cvmfs_builder.subprocess.run", side_effect=_fake_run(0, "")):
+        report = builder.uninstall_module(TOOL, VERSION)
+
+    assert report["registry_tag_removed"] is False
+    assert not marker_dir.exists()
 
 
 def test_uninstall_removes_shelley_state_even_when_shpc_uninstall_fails(builder):

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -32,7 +32,8 @@ def _run(inputs: list, *, side_effect=None):
          patch(f"{_MODULE}.print_warning") as mock_warning, \
          patch(f"{_MODULE}.find_tool_sync") as mock_find, \
          patch(f"{_MODULE}.search_tools") as mock_search, \
-         patch(f"{_MODULE}.build_module") as mock_build:
+         patch(f"{_MODULE}.build_module") as mock_build, \
+         patch(f"{_MODULE}.clean_module") as mock_clean:
 
         mock_console.input = input_mock
 
@@ -43,6 +44,7 @@ def _run(inputs: list, *, side_effect=None):
             "find": mock_find,
             "search": mock_search,
             "build": mock_build,
+            "clean": mock_clean,
             "warning": mock_warning,
             "success": mock_success,
             "info": mock_info,
@@ -175,6 +177,31 @@ def test_build_interactive_flag():
 def test_build_missing_arg_warns():
     mocks = _run(["build", "exit"])
     mocks["build"].assert_not_called()
+    mocks["warning"].assert_called()
+
+
+# ---------------------------------------------------------------------------
+# clean
+# ---------------------------------------------------------------------------
+
+def test_clean_dispatches():
+    mocks = _run(["clean samtools:1.21", "exit"])
+    mocks["clean"].assert_called_once_with("samtools:1.21", force=False)
+
+
+def test_clean_force_flag_dispatches():
+    mocks = _run(["clean samtools:1.21 --force", "exit"])
+    mocks["clean"].assert_called_once_with("samtools:1.21", force=True)
+
+
+def test_clean_force_short_flag_dispatches():
+    mocks = _run(["clean samtools:1.21 -y", "exit"])
+    mocks["clean"].assert_called_once_with("samtools:1.21", force=True)
+
+
+def test_clean_missing_arg_warns():
+    mocks = _run(["clean", "exit"])
+    mocks["clean"].assert_not_called()
     mocks["warning"].assert_called()
 
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -190,11 +190,6 @@ def test_clean_dispatches():
 
 
 def test_clean_force_flag_dispatches():
-    mocks = _run(["clean samtools:1.21 --force", "exit"])
-    mocks["clean"].assert_called_once_with("samtools:1.21", force=True)
-
-
-def test_clean_force_short_flag_dispatches():
     mocks = _run(["clean samtools:1.21 -y", "exit"])
     mocks["clean"].assert_called_once_with("samtools:1.21", force=True)
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -224,3 +224,102 @@ class TestEnsureLocalRegistryEntry:
         assert saved["docker"] == URI
         assert version in saved["tags"]
         assert saved["tags"][version] == "sha256:cafebabe"
+
+    def test_preserves_earlier_local_tag_when_building_a_second_local_only_version(
+        self, builder, tmp_path,
+    ):
+        """Regression: a second locally-curated build of the same tool must not
+        clobber a tag added by an earlier local-only build — only fetch a fresh
+        upstream base when no local file exists yet."""
+        first_version = "1.10.1--0"
+        second_version = "1.8.4--0"
+        registry_yaml = tmp_path / URI / "container.yaml"
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run",
+                   return_value=_curl_success({"docker": URI, "tags": {}, "aliases": []})), \
+             patch("shelley.builder.cvmfs_builder.extract_aliases", return_value=[]), \
+             patch.object(builder, "_compute_sha256", return_value="firstsha"):
+            builder._ensure_local_registry_entry(
+                "samtools", first_version, str(tmp_path / f"samtools:{first_version}"), URI,
+                local_registry=str(tmp_path), in_upstream=False,
+            )
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run") as mock_run, \
+             patch("shelley.builder.cvmfs_builder.extract_aliases", return_value=[]), \
+             patch.object(builder, "_compute_sha256", return_value="secondsha"):
+            builder._ensure_local_registry_entry(
+                "samtools", second_version, str(tmp_path / f"samtools:{second_version}"), URI,
+                local_registry=str(tmp_path), in_upstream=False,
+            )
+            curl_calls = [c for c in mock_run.call_args_list if "curl" in c.args[0]]
+            assert not curl_calls, "must not re-fetch upstream when a local file already exists"
+
+        saved = yaml.safe_load(registry_yaml.read_text())
+        assert saved["tags"][first_version] == "sha256:firstsha"
+        assert saved["tags"][second_version] == "sha256:secondsha"
+
+    def test_per_version_alias_snapshots_do_not_clobber_each_other(self, builder, tmp_path):
+        """Regression for the star-fusion case: config["aliases"] is one shared field,
+        so a second not-upstream build overwrites it with that version's own aliases.
+        Each version's own aliases.yaml snapshot must still be recoverable afterward."""
+        old_version, new_version = "1.0.0--0", "1.9.1--0"
+        old_aliases = [{"name": "STAR", "command": "STAR"}]
+        new_aliases = [{"name": "STAR", "command": "STAR"}, {"name": "salmon", "command": "salmon"}]
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run",
+                   return_value=_curl_success({"docker": URI, "tags": {}, "aliases": []})), \
+             patch("shelley.builder.cvmfs_builder.extract_aliases", return_value=old_aliases), \
+             patch.object(builder, "_compute_sha256", return_value="oldsha"):
+            builder._ensure_local_registry_entry(
+                "samtools", old_version, str(tmp_path / f"samtools:{old_version}"), URI,
+                local_registry=str(tmp_path), in_upstream=False,
+            )
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run"), \
+             patch("shelley.builder.cvmfs_builder.extract_aliases", return_value=new_aliases), \
+             patch.object(builder, "_compute_sha256", return_value="newsha"):
+            builder._ensure_local_registry_entry(
+                "samtools", new_version, str(tmp_path / f"samtools:{new_version}"), URI,
+                local_registry=str(tmp_path), in_upstream=False,
+            )
+
+        # The shared page now only shows the newer build's aliases...
+        saved = yaml.safe_load((tmp_path / URI / "container.yaml").read_text())
+        assert saved["aliases"] == new_aliases
+
+        # ...but each version's own snapshot is still intact and distinct.
+        old_snapshot = yaml.safe_load((tmp_path / URI / old_version / "aliases.yaml").read_text())
+        new_snapshot = yaml.safe_load((tmp_path / URI / new_version / "aliases.yaml").read_text())
+        assert old_snapshot == {"version": old_version, "aliases": old_aliases}
+        assert new_snapshot == {"version": new_version, "aliases": new_aliases}
+
+    def test_creates_marker_directory_only_when_not_in_upstream(self, builder, tmp_path):
+        version = "1.21--h96c455f_1"
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run",
+                   return_value=_curl_success({"docker": URI, "tags": {}, "aliases": []})), \
+             patch.object(builder, "_compute_sha256", return_value="deadbeef"):
+            builder._ensure_local_registry_entry(
+                "samtools", version, str(tmp_path / f"samtools:{version}"), URI,
+                local_registry=str(tmp_path), in_upstream=True,
+            )
+
+        assert not (tmp_path / URI / version).exists()
+
+        with patch("shelley.builder.cvmfs_builder.subprocess.run",
+                   return_value=_curl_success({"docker": URI, "tags": {}, "aliases": []})), \
+             patch("shelley.builder.cvmfs_builder.extract_aliases",
+                   return_value=[{"name": "samtools", "command": "samtools"}]), \
+             patch.object(builder, "_compute_sha256", return_value="deadbeef"):
+            builder._ensure_local_registry_entry(
+                "samtools", "9.9--local", str(tmp_path / "samtools:9.9--local"), URI,
+                local_registry=str(tmp_path), in_upstream=False,
+            )
+
+        marker_dir = tmp_path / URI / "9.9--local"
+        assert marker_dir.is_dir()
+        snapshot = yaml.safe_load((marker_dir / "aliases.yaml").read_text())
+        assert snapshot == {
+            "version": "9.9--local",
+            "aliases": [{"name": "samtools", "command": "samtools"}],
+        }


### PR DESCRIPTION
## Usage

```
shelley build <tool>
shelley clean <tool>/<version> 
shelley clean <tool>/<version> -y # delete without prompting 
```

Add shelley clean to remove a specific tool version (version must always be specified). Removes all shpc and module artefacts such as:
* `/apps/Modules/modulefiles/<tool>/*`
* `/apps/shpc/modules/quay/io/biocontainers/<tool>*`
* For local registries, `/apps/local/quay.io/biocontainers/<tool>`

This PR also adds versioning for local registries so aliases work for specific tool versions with shelley-built registries. For example, `/apps/local/quay.io/biocontainers/<tool>/container.yaml` would be used for all local builds prior (can result in incorrect aliases between versions), now it is `/apps/local/quay.io/biocontainers<version>/<tool>`. This makes `clean` remove specific versions, cleanly.

## Test

* Works fine for registered tools (removes wrappers and modulefiles)
* This tests the edge cases for when you need to delete the local registry for a specific version (issues previously as container.yaml is shared across all versions) 

```
shelley build star-fusion/1.15.1 # in registry
shelley build star-fusion/1.6.0 # no registry
shelley build star-fusion/1.0.0 # no registry
```

```
module avail
```

Correctly builds the multiple versions
```
star-fusion/1.0.0--pl5.22.0_0
star-fusion/1.6.0--1
star-fusion/1.15.1--hdfd78af_1 (D)
```

```
module load singularity star-fusion
```

```
STAR-Fusion --version
# 1.15.0 = correct
```

Correctly prompts when no version specified

```
uv run shelley clean star-fusion
╭─────────────────────────────────────────────────── Not Installed ────────────────────────────────────────────────────╮
│                                                                                                                      │
│  ❌ shelley clean requires an explicit version, e.g. star-fusion:<version>.                                          │
│                                                                                                                      │
│  Suggestion:                                                                                                         │
│  Currently installed versions of 'star-fusion':                                                                      │
│    • 1.0.0--pl5.22.0_0                                                                                               │
│    • 1.15.1--hdfd78af_1                                                                                              │
│    • 1.6.0--1                                                                                                        │
│                                                                                                                      │
│  Re-run with one of these, e.g.:                                                                                     │
│  shelley clean star-fusion:1.0.0--pl5.22.0_0                                                                         │
│                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
uv run shelley clean star-fusion/1.15.1
? Remove star-fusion/1.15.1--hdfd78af_1? This deletes its module, wrappers, and container artifacts. Yes
ℹ️   Running with elevated privileges: clean star-fusion:1.15.1--hdfd78af_1
╭─────────────────────────────────────────────────── Clean Complete ───────────────────────────────────────────────────╮
│                                                                                                                      │
│  ✅ Module Removed                                                                                                   │
│                                                                                                                      │
│  Tool: star-fusion                                                                                                   │
│  Version: 1.15.1--hdfd78af_1                                                                                         │
│                                                                                                                      │
│  Removed:                                                                                                            │
│    • shpc module, wrappers and container artifacts                                                                   │
│    • Lmod modulefile symlink                                                                                         │
│                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
module avail
```
```
star-fusion/1.0.0--pl5.22.0_0
star-fusion/1.6.0--1          (D)
```

```
module purge
module load star-fusion/1.0.0 singularity
STAR-Fusion --version 

# 0.8.0????? Maybe a bug in this version of star-fusion?
```

```
 uv run shelley clean star-fusion/1.0.0
? Remove star-fusion/1.0.0--pl5.22.0_0? This deletes its module, wrappers, and container artifacts. Yes
ℹ️   Running with elevated privileges: clean star-fusion:1.0.0--pl5.22.0_0
╭─────────────────────────────────────────────────── Clean Complete ───────────────────────────────────────────────────╮
│                                                                                                                      │
│  ✅ Module Removed                                                                                                   │
│                                                                                                                      │
│  Tool: star-fusion                                                                                                   │
│  Version: 1.0.0--pl5.22.0_0                                                                                          │
│                                                                                                                      │
│  Removed:                                                                                                            │
│    • shpc module, wrappers and container artifacts                                                                   │
│    • Lmod modulefile symlink                                                                                         │
│                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
ls /apps/local/quay.io/biocontainers/star-fusion
1.6.0--1 # correctly deleted 1.0.0 register
```

```
module load star-fusion/1.6.0
```

```
Lmod has detected the following error:  Unable to load module because of error when evaluating modulefile:
     /apps/Modules/modulefiles/star-fusion/1.6.0--1.lua: [string "-- Lmod Module..."]:925: function or expression needs
too many registers near '"makecontaminatedgenomes.sh"'
     Please check the modulefile and especially if there is a line number specified in the above message 
While processing the following module(s):
    Module fullname       Module Filename
    ---------------       ---------------
    star-fusion/1.6.0--1  /apps/Modules/modulefiles/star-fusion/1.6.0--1.lua
```

This is the same error we had with bcftools where there were waaay too many aliases registered. Ideally run with `shelley build star-fusion/1.6.0 --interactive`, rather than an issue with shelley clean.

```
uv run shelley clean star-fusion/1.6.0
? Remove star-fusion/1.6.0--1? This deletes its module, wrappers, and container artifacts. Yes
ℹ️   Running with elevated privileges: clean star-fusion:1.6.0--1
╭─────────────────────────────────────────────────── Clean Complete ───────────────────────────────────────────────────╮
│                                                                                                                      │
│  ✅ Module Removed                                                                                                   │
│                                                                                                                      │
│  Tool: star-fusion                                                                                                   │
│  Version: 1.6.0--1                                                                                                   │
│                                                                                                                      │
│  Removed:                                                                                                            │
│    • shpc module, wrappers and container artifacts                                                                   │
│    • Lmod modulefile symlink                                                                                         │
│                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
ls /apps/local/quay.io/biocontainers/star-fusion
# empty :)
```

Double check modules
```
ls /apps/Modules/modulefiles | grep star
# no star-fusion :)
```
